### PR TITLE
fix(repo) INT-248: @netacea/f5 version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": "6.9.1"
   },
   "dependencies": {
-    "@netacea/f5": "^1.4.0",
+    "@netacea/f5": "^1.5.7",
     "core-js": "^3.8.0",
     "f5-nodejs": "^1.0.0",
     "regenerator-runtime": "^0.13.7"


### PR DESCRIPTION
See: [INT-248](https://netacea.atlassian.net/browse/INT-248)

Public template has been using old version of the @netacea/f5 package and it requires an update to a newer version.

## PR Tasks

Tick these off as you go - delete as appropriate:

- [x] Link to correct Jira ticket above
- [x] Name the PR in a human readable format e.g. "TIC-123 Ticket title"
- [x] Update the description above
- [x] Make sure your PR is targeting the main branch
- [x] Make sure you've had a review from a developer
- [x] Respond to any feedback and close any unresolved conversations

## Help

If you need any help with this PR please post in the `#integrations-team` channel on slack.


